### PR TITLE
Add basic Dixon & Coles model

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Tests and linting
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   tests:
@@ -30,6 +30,7 @@ jobs:
         run: |
           poetry run black . --check
           poetry run isort . -c -v
+          poetry run pylint bpl
 
       - name: Test with pytest
         run: poetry run pytest --cov .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,8 +28,8 @@ jobs:
 
       - name: Code Quality
         run: |
-          poetry run black . --check
-          poetry run isort . -c -v
+          poetry run black bpl --check
+          poetry run isort bpl -c -v
           poetry run pylint bpl
 
       - name: Test with pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# this project
+sandbox/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,7 @@
+[MESSAGES CONTROL]
+disable=invalid-name
+
+[SIMILARITIES]
+min-similarity-lines=7
+ignore-comments=yes
+ignore-docstrings=yes

--- a/bpl/__init__.py
+++ b/bpl/__init__.py
@@ -1,2 +1,4 @@
 # pylint: disable=missing-module-docstring
 __version__ = "0.1.0"
+
+from bpl.dixon_coles import DixonColesMatchPredictor

--- a/bpl/__init__.py
+++ b/bpl/__init__.py
@@ -1,1 +1,2 @@
+# pylint: disable=missing-module-docstring
 __version__ = "0.1.0"

--- a/bpl/base.py
+++ b/bpl/base.py
@@ -1,33 +1,24 @@
 """Implementation of the probabilistic model for soccer matches."""
 from __future__ import annotations
 
-from abc import abstractmethod, abstractproperty
+from abc import abstractmethod
 from typing import Dict, Iterable, Union
 
+import jax.numpy as jnp
 import numpy as np
+
+
+MAX_GOALS = 15
 
 
 class BaseMatchPredictor:
     """Abstract class for models of football matches."""
 
     @abstractmethod
-    def predict_outcome_proba(
-        self, home_team: Union[str, Iterable[str]], away_team: Union[str, Iterable[str]]
-    ) -> Dict[str, Union[float, np.ndarray]]:
-        """Calculate home win, away win and draw probabilities.
-
-        Given a home team and away team (or lists thereof), calculate the probabilites
-        of the overall results (home win, away win, draw).
-
-        Args:
-            home_team (Union[str, Iterable[str]]): name of the home team(s).
-            away_team (Union[str, Iterable[str]]): name of the away team(s).
-
-        Returns:
-            Dict[str, Union[float, np.ndarray]]: A dictionary with keys "home_win",
-                "away_win" and "draw". Values are probabilities of each outcome.
-        """
-        pass
+    def fit(
+        self, training_data: Dict[str, Union[Iterable[str], Iterable[float]]], **kwargs
+    ) -> BaseMatchPredictor:
+        """Fit the model to data and return self."""
 
     @abstractmethod
     def predict_score_proba(
@@ -36,7 +27,7 @@ class BaseMatchPredictor:
         away_team: Union[str, Iterable[str]],
         home_goals: Union[float, Iterable[float]],
         away_goals: Union[float, Iterable[float]],
-    ) -> Union[float, np.ndarray]:
+    ) -> jnp.array:
         """Return the probability of a particular scoreline.
 
         Args:
@@ -50,10 +41,42 @@ class BaseMatchPredictor:
         Returns:
             float: the probability of the given outcome.
         """
-        pass
 
-    @abstractmethod
-    def fit(
-        self, training_data: Dict[str, Union[Iterable[str], Iterable[float]]]
-    ) -> BaseMatchPredictor:
-        pass
+    def predict_outcome_proba(
+        self, home_team: Union[str, Iterable[str]], away_team: Union[str, Iterable[str]]
+    ) -> Dict[str, jnp.array]:
+        """Calculate home win, away win and draw probabilities.
+
+        Given a home team and away team (or lists thereof), calculate the probabilites
+        of the overall results (home win, away win, draw).
+
+        Args:
+            home_team (Union[str, Iterable[str]]): name of the home team(s).
+            away_team (Union[str, Iterable[str]]): name of the away team(s).
+
+        Returns:
+            Dict[str, Union[float, np.ndarray]]: A dictionary with keys "home_win",
+                "away_win" and "draw". Values are probabilities of each outcome.
+        """
+        home_team = [home_team] if isinstance(home_team, str) else home_team
+        away_team = [away_team] if isinstance(away_team, str) else away_team
+
+        # make a grid of scorelines up to plausible limits
+        n_goals = np.arange(0, MAX_GOALS + 1)
+        x, y = np.meshgrid(n_goals, n_goals, indexing="ij")
+        x_flat = jnp.tile(x.reshape((MAX_GOALS + 1) ** 2), len(home_team))
+        y_flat = jnp.tile(y.reshape((MAX_GOALS + 1) ** 2), len(home_team))
+        home_team_rep = np.repeat(home_team, (MAX_GOALS + 1) ** 2)
+        away_team_rep = np.repeat(away_team, (MAX_GOALS + 1) ** 2)
+
+        # evaluate the probability of scorelines at each gridpoint
+        probs = self.predict_score_proba(
+            home_team_rep, away_team_rep, x_flat, y_flat
+        ).reshape(len(home_team), MAX_GOALS + 1, MAX_GOALS + 1)
+
+        # obtain outcome probabilities by summing the appropriate elements of the grid
+        prob_home_win = probs[:, x > y].sum(axis=-1)
+        prob_away_win = probs[:, x < y].sum(axis=-1)
+        prob_draw = probs[:, x == y].sum(axis=-1)
+
+        return {"home_win": prob_home_win, "away_win": prob_away_win, "draw": prob_draw}

--- a/bpl/base.py
+++ b/bpl/base.py
@@ -7,7 +7,6 @@ from typing import Dict, Iterable, Union
 import jax.numpy as jnp
 import numpy as np
 
-
 MAX_GOALS = 15
 
 

--- a/bpl/base.py
+++ b/bpl/base.py
@@ -1,0 +1,59 @@
+"""Implementation of the probabilistic model for soccer matches."""
+from __future__ import annotations
+
+from abc import abstractmethod, abstractproperty
+from typing import Dict, Iterable, Union
+
+import numpy as np
+
+
+class BaseMatchPredictor:
+    """Abstract class for models of football matches."""
+
+    @abstractmethod
+    def predict_outcome_proba(
+        self, home_team: Union[str, Iterable[str]], away_team: Union[str, Iterable[str]]
+    ) -> Dict[str, Union[float, np.ndarray]]:
+        """Calculate home win, away win and draw probabilities.
+
+        Given a home team and away team (or lists thereof), calculate the probabilites
+        of the overall results (home win, away win, draw).
+
+        Args:
+            home_team (Union[str, Iterable[str]]): name of the home team(s).
+            away_team (Union[str, Iterable[str]]): name of the away team(s).
+
+        Returns:
+            Dict[str, Union[float, np.ndarray]]: A dictionary with keys "home_win",
+                "away_win" and "draw". Values are probabilities of each outcome.
+        """
+        pass
+
+    @abstractmethod
+    def predict_score_proba(
+        self,
+        home_team: Union[str, Iterable[str]],
+        away_team: Union[str, Iterable[str]],
+        home_goals: Union[float, Iterable[float]],
+        away_goals: Union[float, Iterable[float]],
+    ) -> Union[float, np.ndarray]:
+        """Return the probability of a particular scoreline.
+
+        Args:
+            home_team (Union[str, Iterable[str]]): name of the home team(s).
+            away_team (Union[str, Iterable[str]]): name of the away team(s).
+            home_goals (Union[float, Iterable[float]]): number of goals scored by 
+                the home team(s).
+            away_goals (Union[float, Iterable[float]]): number of goals scored by 
+                the away team(s).
+
+        Returns:
+            float: the probability of the given outcome.
+        """
+        pass
+
+    @abstractmethod
+    def fit(
+        self, training_data: Dict[str, Union[Iterable[str], Iterable[float]]]
+    ) -> BaseMatchPredictor:
+        pass

--- a/bpl/base.py
+++ b/bpl/base.py
@@ -42,9 +42,9 @@ class BaseMatchPredictor:
         Args:
             home_team (Union[str, Iterable[str]]): name of the home team(s).
             away_team (Union[str, Iterable[str]]): name of the away team(s).
-            home_goals (Union[float, Iterable[float]]): number of goals scored by 
+            home_goals (Union[float, Iterable[float]]): number of goals scored by
                 the home team(s).
-            away_goals (Union[float, Iterable[float]]): number of goals scored by 
+            away_goals (Union[float, Iterable[float]]): number of goals scored by
                 the away team(s).
 
         Returns:

--- a/bpl/dixon_coles.py
+++ b/bpl/dixon_coles.py
@@ -1,17 +1,16 @@
 """Implementation of a simple team level model."""
 from __future__ import annotations
 
-from typing import Dict, Iterable, Optional, Union
+from typing import Any, Dict, Iterable, Optional, Union
 
 import jax
 import jax.numpy as jnp
 import numpy as np
 import numpyro
 import numpyro.distributions as dist
-from numpyro.infer.reparam import LocScaleReparam
 from numpyro.handlers import reparam
 from numpyro.infer import MCMC, NUTS
-
+from numpyro.infer.reparam import LocScaleReparam
 
 from bpl.base import BaseMatchPredictor
 
@@ -54,7 +53,6 @@ class DixonColesMatchPredictor(BaseMatchPredictor):
         self.defence = None
         self.home_advantage = None
         self.corr_coef = None
-
 
     def _model(
         self,
@@ -113,7 +111,7 @@ class DixonColesMatchPredictor(BaseMatchPredictor):
         home_ind = jnp.array([self.teams.index(t) for t in home_team])
         away_ind = jnp.array([self.teams.index(t) for t in away_team])
 
-        nuts_kernel = NUTS(model)
+        nuts_kernel = NUTS(self._model)
         mcmc = MCMC(nuts_kernel, **(mcmc_kwargs or {}))
         rng_key = jax.random.PRNGKey(random_state)
         mcmc.run(
@@ -121,8 +119,8 @@ class DixonColesMatchPredictor(BaseMatchPredictor):
             home_ind,
             away_ind,
             len(self.teams),
-            jnp.array(training_data["home_goals"],
-            jnp.array(training_data["away_goals"],
+            jnp.array(training_data["home_goals"]),
+            jnp.array(training_data["away_goals"]),
             **(run_kwargs or {})
         )
 

--- a/bpl/dixon_coles.py
+++ b/bpl/dixon_coles.py
@@ -14,8 +14,6 @@ from numpyro.infer.reparam import LocScaleReparam
 
 from bpl.base import BaseMatchPredictor
 
-MAX_GOALS = 15
-
 
 def _correlation_term(home_goals, away_goals, home_rate, away_rate, corr_coef):
     # correlation term from dixon and coles paper

--- a/bpl/dixon_coles.py
+++ b/bpl/dixon_coles.py
@@ -14,6 +14,8 @@ from numpyro.infer.reparam import LocScaleReparam
 
 from bpl.base import BaseMatchPredictor
 
+__all__ = ["DixonColesMatchPredictor"]
+
 
 def _correlation_term(home_goals, away_goals, home_rate, away_rate, corr_coef):
     # correlation term from dixon and coles paper

--- a/bpl/dixon_coles.py
+++ b/bpl/dixon_coles.py
@@ -1,0 +1,135 @@
+"""Implementation of a simple team level model."""
+from __future__ import annotations
+
+from typing import Dict, Iterable, Optional, Union
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import numpyro
+import numpyro.distributions as dist
+from numpyro.infer.reparam import LocScaleReparam
+from numpyro.handlers import reparam
+from numpyro.infer import MCMC, NUTS
+
+
+from bpl.base import BaseMatchPredictor
+
+
+def _correlation_term(home_goals, away_goals, home_rate, away_rate, corr_coef):
+    # correlation term from dixon and coles paper
+    corr_term = jnp.zeros_like(home_rate)
+
+    nil_nil = (home_goals == 0) & (away_goals == 0)
+    corr_term = jax.ops.index_update(
+        corr_term,
+        (..., nil_nil),
+        jnp.log(1.0 - corr_coef * home_rate[..., nil_nil] * away_rate[..., nil_nil]),
+    )
+
+    one_nil = (home_goals == 1) & (away_goals == 0)
+    corr_term = jax.ops.index_update(
+        corr_term, (..., one_nil), jnp.log(1.0 + corr_coef * away_rate[..., one_nil])
+    )
+
+    nil_one = (home_goals == 0) & (away_goals == 1)
+    corr_term = jax.ops.index_update(
+        corr_term, (..., nil_one), jnp.log(1.0 + corr_coef * home_rate[..., nil_one])
+    )
+
+    one_one = (home_goals == 1) & (away_goals == 1)
+    corr_term = jax.ops.index_update(
+        corr_term, (..., one_one), jnp.log(1.0 - corr_coef)
+    )
+
+    return corr_term.sum(axis=-1)
+
+
+class DixonColesMatchPredictor(BaseMatchPredictor):
+    """A Dixon-Coles like model for predicting match outcomes."""
+
+    def __init__(self):
+        self.teams = None
+        self.attack = None
+        self.defence = None
+        self.home_advantage = None
+        self.corr_coef = None
+
+
+    def _model(
+        self,
+        home_team: jnp.array,
+        away_team: jnp.array,
+        num_teams: int,
+        home_goals: Optional[Iterable[float]],
+        away_goals: Optional[Iterable[float]],
+    ):
+        std_attack = numpyro.sample("std_attack", dist.HalfNormal(1.0))
+        std_defence = numpyro.sample("std_defence", dist.HalfNormal(1.0))
+        mean_defence = numpyro.sample("mean_defence", dist.Normal(0.0, 1.0))
+        home_advantage = numpyro.sample("home_advantage", dist.Normal(0.1, 0.2))
+        corr_coef = numpyro.sample("corr_coef", dist.Normal(0.0, 1.0))
+
+        with numpyro.plate("teams", num_teams):
+            with reparam(
+                config={
+                    "attack": LocScaleReparam(centered=0),
+                    "defence": LocScaleReparam(centered=0),
+                }
+            ):
+                attack = numpyro.sample("attack", dist.Normal(0.0, std_attack))
+                defence = numpyro.sample(
+                    "defence", dist.Normal(mean_defence, std_defence)
+                )
+
+        expected_home_goals = jnp.exp(
+            attack[home_team] - defence[away_team] + home_advantage
+        )
+        expected_away_goals = jnp.exp(attack[away_team] - defence[home_team])
+
+        numpyro.sample(
+            "home_goals", dist.Poisson(expected_home_goals).to_event(1), obs=home_goals
+        )
+        numpyro.sample(
+            "away_goals", dist.Poisson(expected_away_goals).to_event(1), obs=away_goals
+        )
+
+        corr_term = _correlation_term(
+            home_goals, away_goals, expected_home_goals, expected_away_goals, corr_coef
+        )
+        numpyro.factor("correlation_term", corr_term)
+
+    def fit(
+        self,
+        training_data: Dict[str, Union[Iterable[str], Iterable[float]]],
+        random_state: int = 42,
+        mcmc_kwargs: Optional[Dict[str, Any]] = None,
+        run_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> DixonColesMatchPredictor:
+        home_team = training_data["home_team"]
+        away_team = training_data["away_team"]
+
+        self.teams = sorted(list(set(home_team) | set(away_team)))
+        home_ind = jnp.array([self.teams.index(t) for t in home_team])
+        away_ind = jnp.array([self.teams.index(t) for t in away_team])
+
+        nuts_kernel = NUTS(model)
+        mcmc = MCMC(nuts_kernel, **(mcmc_kwargs or {}))
+        rng_key = jax.random.PRNGKey(random_state)
+        mcmc.run(
+            rng_key,
+            home_ind,
+            away_ind,
+            len(self.teams),
+            jnp.array(training_data["home_goals"],
+            jnp.array(training_data["away_goals"],
+            **(run_kwargs or {})
+        )
+
+        samples = mcmc.get_samples()
+        self.attack = samples["attack"]
+        self.defence = samples["defence"]
+        self.home_advantage = samples["home_advantage"]
+        self.corr_coef = samples["corr_coef"]
+
+        return self

--- a/poetry.lock
+++ b/poetry.lock
@@ -222,22 +222,6 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 pyparsing = ">=2.0.2"
 
 [[package]]
-name = "pandas"
-version = "1.2.3"
-description = "Powerful data structures for data analysis, time series, and statistics"
-category = "main"
-optional = false
-python-versions = ">=3.7.1"
-
-[package.dependencies]
-numpy = ">=1.16.5"
-python-dateutil = ">=2.7.3"
-pytz = ">=2017.3"
-
-[package.extras]
-test = ["pytest (>=5.0.1)", "pytest-xdist", "hypothesis (>=3.58)"]
-
-[[package]]
 name = "pathspec"
 version = "0.8.1"
 description = "Utility library for gitignore style pattern matching of file paths."
@@ -312,25 +296,6 @@ pytest = ">=4.6"
 
 [package.extras]
 testing = ["fields", "hunter", "process-tests (==2.0.2)", "six", "pytest-xdist", "virtualenv"]
-
-[[package]]
-name = "python-dateutil"
-version = "2.8.1"
-description = "Extensions to the standard Python datetime module"
-category = "main"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-
-[package.dependencies]
-six = ">=1.5"
-
-[[package]]
-name = "pytz"
-version = "2021.1"
-description = "World timezone definitions, modern and historical"
-category = "main"
-optional = false
-python-versions = "*"
 
 [[package]]
 name = "regex"
@@ -419,7 +384,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<4.0"
-content-hash = "cb75370b0bd7e45bfe1fb17da36aeb0b7e8bea14fc187cfa06f7c29da75944ce"
+content-hash = "06fa2bc6af269f535ab624db9c689b4fca00f465dd45e57e8d7328076cac9b9b"
 
 [metadata.files]
 absl-py = [
@@ -574,24 +539,6 @@ packaging = [
     {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
     {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
 ]
-pandas = [
-    {file = "pandas-1.2.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:4d821b9b911fc1b7d428978d04ace33f0af32bb7549525c8a7b08444bce46b74"},
-    {file = "pandas-1.2.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:9f5829e64507ad10e2561b60baf285c470f3c4454b007c860e77849b88865ae7"},
-    {file = "pandas-1.2.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:97b1954533b2a74c7e20d1342c4f01311d3203b48f2ebf651891e6a6eaf01104"},
-    {file = "pandas-1.2.3-cp37-cp37m-win32.whl", hash = "sha256:5e3c8c60541396110586bcbe6eccdc335a38e7de8c217060edaf4722260b158f"},
-    {file = "pandas-1.2.3-cp37-cp37m-win_amd64.whl", hash = "sha256:8a051e957c5206f722e83f295f95a2cf053e890f9a1fba0065780a8c2d045f5d"},
-    {file = "pandas-1.2.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a93e34f10f67d81de706ce00bf8bb3798403cabce4ccb2de10c61b5ae8786ab5"},
-    {file = "pandas-1.2.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:46fc671c542a8392a4f4c13edc8527e3a10f6cb62912d856f82248feb747f06e"},
-    {file = "pandas-1.2.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:43e00770552595c2250d8d712ec8b6e08ca73089ac823122344f023efa4abea3"},
-    {file = "pandas-1.2.3-cp38-cp38-win32.whl", hash = "sha256:475b7772b6e18a93a43ea83517932deff33954a10d4fbae18d0c1aba4182310f"},
-    {file = "pandas-1.2.3-cp38-cp38-win_amd64.whl", hash = "sha256:72ffcea00ae8ffcdbdefff800284311e155fbb5ed6758f1a6110fc1f8f8f0c1c"},
-    {file = "pandas-1.2.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:621c044a1b5e535cf7dcb3ab39fca6f867095c3ef223a524f18f60c7fee028ea"},
-    {file = "pandas-1.2.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:0f27fd1adfa256388dc34895ca5437eaf254832223812afd817a6f73127f969c"},
-    {file = "pandas-1.2.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:dbb255975eb94143f2e6ec7dadda671d25147939047839cd6b8a4aff0379bb9b"},
-    {file = "pandas-1.2.3-cp39-cp39-win32.whl", hash = "sha256:d59842a5aa89ca03c2099312163ffdd06f56486050e641a45d926a072f04d994"},
-    {file = "pandas-1.2.3-cp39-cp39-win_amd64.whl", hash = "sha256:09761bf5f8c741d47d4b8b9073288de1be39bbfccc281d70b889ade12b2aad29"},
-    {file = "pandas-1.2.3.tar.gz", hash = "sha256:df6f10b85aef7a5bb25259ad651ad1cc1d6bb09000595cab47e718cbac250b1d"},
-]
 pathspec = [
     {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
     {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
@@ -615,14 +562,6 @@ pytest = [
 pytest-cov = [
     {file = "pytest-cov-2.11.1.tar.gz", hash = "sha256:359952d9d39b9f822d9d29324483e7ba04a3a17dd7d05aa6beb7ea01e359e5f7"},
     {file = "pytest_cov-2.11.1-py2.py3-none-any.whl", hash = "sha256:bdb9fdb0b85a7cc825269a4c56b48ccaa5c7e365054b6038772c32ddcdc969da"},
-]
-python-dateutil = [
-    {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
-    {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
-]
-pytz = [
-    {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},
-    {file = "pytz-2021.1.tar.gz", hash = "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da"},
 ]
 regex = [
     {file = "regex-2021.3.17-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b97ec5d299c10d96617cc851b2e0f81ba5d9d6248413cd374ef7f3a8871ee4a6"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -18,6 +18,19 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "astroid"
+version = "2.5.2"
+description = "An abstract syntax tree for Python with inference support."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+lazy-object-proxy = ">=1.4.0"
+typed-ast = {version = ">=1.4.0,<1.5", markers = "implementation_name == \"cpython\" and python_version < \"3.8\""}
+wrapt = ">=1.11,<1.13"
+
+[[package]]
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
@@ -153,6 +166,22 @@ numpy = ">=1.16"
 scipy = "*"
 
 [[package]]
+name = "lazy-object-proxy"
+version = "1.6.0"
+description = "A fast and thorough lazy object proxy."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[[package]]
+name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "more-itertools"
 version = "8.7.0"
 description = "More routines for operating on iterables, beyond itertools"
@@ -250,6 +279,24 @@ description = "library with cross-python path, ini-parsing, io, code, log facili
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pylint"
+version = "2.7.4"
+description = "python code static checker"
+category = "dev"
+optional = false
+python-versions = "~=3.6"
+
+[package.dependencies]
+astroid = ">=2.5.2,<2.7"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+isort = ">=4.2.5,<6"
+mccabe = ">=0.6,<0.7"
+toml = ">=0.7.1"
+
+[package.extras]
+docs = ["sphinx (==3.5.1)", "python-docs-theme (==2020.12)"]
 
 [[package]]
 name = "pyparsing"
@@ -370,6 +417,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "wrapt"
+version = "1.12.1"
+description = "Module for decorators, wrappers and monkey patching."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "zipp"
 version = "3.4.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -384,7 +439,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<4.0"
-content-hash = "06fa2bc6af269f535ab624db9c689b4fca00f465dd45e57e8d7328076cac9b9b"
+content-hash = "a2329b17a448403a99f171fc8215e1305b902e760f0f11b3866d23457886ebfe"
 
 [metadata.files]
 absl-py = [
@@ -394,6 +449,10 @@ absl-py = [
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
     {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
+]
+astroid = [
+    {file = "astroid-2.5.2-py3-none-any.whl", hash = "sha256:cd80bf957c49765dce6d92c43163ff9d2abc43132ce64d4b1b47717c6d2522df"},
+    {file = "astroid-2.5.2.tar.gz", hash = "sha256:6b0ed1af831570e500e2437625979eaa3b36011f66ddfc4ce930128610258ca9"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -493,6 +552,34 @@ jaxlib = [
     {file = "jaxlib-0.1.62-cp39-none-macosx_10_9_x86_64.whl", hash = "sha256:42d6aff8a7262da6f69b55ecf64847ec741b164e179168f5be6008c23c956edf"},
     {file = "jaxlib-0.1.62-cp39-none-manylinux2010_x86_64.whl", hash = "sha256:bb878ea37bacd121ac183144998a466aa119859930b787393ea74f7034e0660b"},
 ]
+lazy-object-proxy = [
+    {file = "lazy-object-proxy-1.6.0.tar.gz", hash = "sha256:489000d368377571c6f982fba6497f2aa13c6d1facc40660963da62f5c379726"},
+    {file = "lazy_object_proxy-1.6.0-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:c6938967f8528b3668622a9ed3b31d145fab161a32f5891ea7b84f6b790be05b"},
+    {file = "lazy_object_proxy-1.6.0-cp27-cp27m-win32.whl", hash = "sha256:ebfd274dcd5133e0afae738e6d9da4323c3eb021b3e13052d8cbd0e457b1256e"},
+    {file = "lazy_object_proxy-1.6.0-cp27-cp27m-win_amd64.whl", hash = "sha256:ed361bb83436f117f9917d282a456f9e5009ea12fd6de8742d1a4752c3017e93"},
+    {file = "lazy_object_proxy-1.6.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:d900d949b707778696fdf01036f58c9876a0d8bfe116e8d220cfd4b15f14e741"},
+    {file = "lazy_object_proxy-1.6.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5743a5ab42ae40caa8421b320ebf3a998f89c85cdc8376d6b2e00bd12bd1b587"},
+    {file = "lazy_object_proxy-1.6.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:bf34e368e8dd976423396555078def5cfc3039ebc6fc06d1ae2c5a65eebbcde4"},
+    {file = "lazy_object_proxy-1.6.0-cp36-cp36m-win32.whl", hash = "sha256:b579f8acbf2bdd9ea200b1d5dea36abd93cabf56cf626ab9c744a432e15c815f"},
+    {file = "lazy_object_proxy-1.6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:4f60460e9f1eb632584c9685bccea152f4ac2130e299784dbaf9fae9f49891b3"},
+    {file = "lazy_object_proxy-1.6.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d7124f52f3bd259f510651450e18e0fd081ed82f3c08541dffc7b94b883aa981"},
+    {file = "lazy_object_proxy-1.6.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:22ddd618cefe54305df49e4c069fa65715be4ad0e78e8d252a33debf00f6ede2"},
+    {file = "lazy_object_proxy-1.6.0-cp37-cp37m-win32.whl", hash = "sha256:9d397bf41caad3f489e10774667310d73cb9c4258e9aed94b9ec734b34b495fd"},
+    {file = "lazy_object_proxy-1.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:24a5045889cc2729033b3e604d496c2b6f588c754f7a62027ad4437a7ecc4837"},
+    {file = "lazy_object_proxy-1.6.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:17e0967ba374fc24141738c69736da90e94419338fd4c7c7bef01ee26b339653"},
+    {file = "lazy_object_proxy-1.6.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:410283732af311b51b837894fa2f24f2c0039aa7f220135192b38fcc42bd43d3"},
+    {file = "lazy_object_proxy-1.6.0-cp38-cp38-win32.whl", hash = "sha256:85fb7608121fd5621cc4377a8961d0b32ccf84a7285b4f1d21988b2eae2868e8"},
+    {file = "lazy_object_proxy-1.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:d1c2676e3d840852a2de7c7d5d76407c772927addff8d742b9808fe0afccebdf"},
+    {file = "lazy_object_proxy-1.6.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:b865b01a2e7f96db0c5d12cfea590f98d8c5ba64ad222300d93ce6ff9138bcad"},
+    {file = "lazy_object_proxy-1.6.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:4732c765372bd78a2d6b2150a6e99d00a78ec963375f236979c0626b97ed8e43"},
+    {file = "lazy_object_proxy-1.6.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:9698110e36e2df951c7c36b6729e96429c9c32b3331989ef19976592c5f3c77a"},
+    {file = "lazy_object_proxy-1.6.0-cp39-cp39-win32.whl", hash = "sha256:1fee665d2638491f4d6e55bd483e15ef21f6c8c2095f235fef72601021e64f61"},
+    {file = "lazy_object_proxy-1.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:f5144c75445ae3ca2057faac03fda5a902eff196702b0a24daf1d6ce0650514b"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
 more-itertools = [
     {file = "more-itertools-8.7.0.tar.gz", hash = "sha256:c5d6da9ca3ff65220c3bfd2a8db06d698f05d4d2b9be57e1deb2be5a45019713"},
     {file = "more_itertools-8.7.0-py3-none-any.whl", hash = "sha256:5652a9ac72209ed7df8d9c15daf4e1aa0e3d2ccd3c87f8265a0673cd9cbc9ced"},
@@ -550,6 +637,10 @@ pluggy = [
 py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
     {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
+]
+pylint = [
+    {file = "pylint-2.7.4-py3-none-any.whl", hash = "sha256:209d712ec870a0182df034ae19f347e725c1e615b2269519ab58a35b3fcbbe7a"},
+    {file = "pylint-2.7.4.tar.gz", hash = "sha256:bd38914c7731cdc518634a8d3c5585951302b6e2b6de60fbb3f7a0220e21eeee"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
@@ -679,6 +770,9 @@ typing-extensions = [
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
     {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
+]
+wrapt = [
+    {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},
 ]
 zipp = [
     {file = "zipp-3.4.1-py3-none-any.whl", hash = "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ pytest = "^5.2"
 black = "^20.8b1"
 isort = "^5.8.0"
 pytest-cov = "^2.11.1"
+pylint = "^2.7.4"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ authors = ["Angus Williams <anguswilliams91@gmail.com>"]
 [tool.poetry.dependencies]
 python = ">=3.7.1,<4.0"
 numpyro = "^0.6.0"
-pandas = "^1.2.3"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def dummy_data():
+    home_team = np.tile(["A", "B", "C", "D"], 20)
+    away_team = np.tile(["D", "A", "B", "C"], 20)
+    home_goals = np.tile(np.array([3, 0, 1, 2]), 20)
+    away_goals = np.tile(np.array([0, 2, 1, 1]), 20)
+    return {
+        "home_team": home_team,
+        "away_team": away_team,
+        "home_goals": home_goals,
+        "away_goals": away_goals,
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,27 @@
+import itertools
+
 import numpy as np
 import pytest
 
 
 @pytest.fixture
 def dummy_data():
-    home_team = np.tile(["A", "B", "C", "D"], 20)
-    away_team = np.tile(["D", "A", "B", "C"], 20)
-    home_goals = np.tile(np.array([3, 0, 1, 2]), 20)
-    away_goals = np.tile(np.array([0, 2, 1, 1]), 20)
+
+    np.random.seed(42)
+    home_mean = 2.1
+    away_mean = 1.7
+
+    home_goals = np.random.poisson(home_mean, size=190)
+    away_goals = np.random.poisson(away_mean, size=190)
+
+    teams = [str(i) for i in range(20)]
+    matchups = itertools.combinations(teams, 2)
+    home_team = []
+    away_team = []
+    for a, b in matchups:
+        home_team.append(a)
+        away_team.append(b)
+
     return {
         "home_team": home_team,
         "away_team": away_team,

--- a/tests/test_all_models.py
+++ b/tests/test_all_models.py
@@ -2,7 +2,7 @@
 import jax.numpy as jnp
 import pytest
 
-from bpl.dixon_coles import DixonColesMatchPredictor
+from bpl import DixonColesMatchPredictor
 
 MODELS = [DixonColesMatchPredictor]
 

--- a/tests/test_all_models.py
+++ b/tests/test_all_models.py
@@ -1,0 +1,39 @@
+"""Shared tests across all models, e.g. checking probabilities are valid."""
+import jax.numpy as jnp
+import pytest
+
+from bpl.dixon_coles import DixonColesMatchPredictor
+
+MODELS = [DixonColesMatchPredictor]
+
+
+@pytest.mark.parametrize("model_cls", MODELS)
+def test_predict_score_proba(dummy_data, model_cls):
+
+    model = model_cls().fit(dummy_data, num_samples=100, num_warmup=100)
+
+    probs = model.predict_score_proba(
+        dummy_data["home_team"],
+        dummy_data["away_team"],
+        dummy_data["home_goals"],
+        dummy_data["away_goals"],
+    )
+
+    assert jnp.all(0 <= probs <= 1)
+
+    prob_single = model.predict_score_proba("A", "B", 1, 0)[0]
+    assert 0 <= prob_single <= 1
+
+
+@pytest.mark.parametrize("model_cls", MODELS)
+def test_predict_outcome_proba(dummy_data, model_cls):
+    model = model_cls().fit(dummy_data, num_samples=100, num_warmup=100)
+
+    probs = model.predict_outcome_proba(
+        dummy_data["home_team"], dummy_data["away_team"]
+    )
+
+    assert jnp.all(0 <= probs <= 1)
+
+    prob_single = model.predict_outcome_proba("A", "B")
+    assert 0 <= prob_single <= 1

--- a/tests/test_all_models.py
+++ b/tests/test_all_models.py
@@ -19,9 +19,9 @@ def test_predict_score_proba(dummy_data, model_cls):
         dummy_data["away_goals"],
     )
 
-    assert jnp.all(0 <= probs <= 1)
+    assert jnp.all((probs >= 0) & (probs <= 1))
 
-    prob_single = model.predict_score_proba("A", "B", 1, 0)[0]
+    prob_single = model.predict_score_proba("0", "1", 1, 0)[0]
     assert 0 <= prob_single <= 1
 
 
@@ -33,7 +33,12 @@ def test_predict_outcome_proba(dummy_data, model_cls):
         dummy_data["home_team"], dummy_data["away_team"]
     )
 
-    assert jnp.all(0 <= probs <= 1)
+    total_probability = probs["home_win"] + probs["away_win"] + probs["draw"]
 
-    prob_single = model.predict_outcome_proba("A", "B")
-    assert 0 <= prob_single <= 1
+    assert jnp.allclose(total_probability, 1.0, atol=1e-5)
+
+    prob_single = model.predict_outcome_proba("0", "1")
+    assert prob_single["home_win"] + prob_single["away_win"] + prob_single[
+        "draw"
+    ] == pytest.approx(1.0, abs=1e-5)
+

--- a/tests/test_bpl.py
+++ b/tests/test_bpl.py
@@ -1,5 +1,0 @@
-from bpl import __version__
-
-
-def test_version():
-    assert __version__ == "0.1.0"

--- a/tests/test_dixon_coles.py
+++ b/tests/test_dixon_coles.py
@@ -4,11 +4,6 @@ import pytest
 from bpl.dixon_coles import DixonColesMatchPredictor
 
 
-@pytest.fixture
-def fitted_model(dummy_data):
-    return DixonColesMatchPredictor().fit(dummy_data, num_samples=100, num_warmup=100)
-
-
 def test_fit(dummy_data):
     model = DixonColesMatchPredictor().fit(dummy_data)
 
@@ -17,18 +12,3 @@ def test_fit(dummy_data):
     assert model.home_advantage is not None
     assert model.teams is not None
     assert model.corr_coef is not None
-
-
-def test_predict_score_proba(dummy_data, fitted_model):
-
-    probs = fitted_model.predict_score_proba(
-        dummy_data["home_team"],
-        dummy_data["away_team"],
-        dummy_data["home_goals"],
-        dummy_data["away_goals"],
-    )
-
-    assert jnp.all((probs >= 0.0) <= (probs <= 1.0))
-
-    prob_single = fitted_model.predict_score_proba("A", "B", 1, 0)[0]
-    assert (prob_single >= 0) and (prob_single <= 1)

--- a/tests/test_dixon_coles.py
+++ b/tests/test_dixon_coles.py
@@ -1,0 +1,34 @@
+import jax.numpy as jnp
+import pytest
+
+from bpl.dixon_coles import DixonColesMatchPredictor
+
+
+@pytest.fixture
+def fitted_model(dummy_data):
+    return DixonColesMatchPredictor().fit(dummy_data, num_samples=100, num_warmup=100)
+
+
+def test_fit(dummy_data):
+    model = DixonColesMatchPredictor().fit(dummy_data)
+
+    assert model.attack is not None
+    assert model.defence is not None
+    assert model.home_advantage is not None
+    assert model.teams is not None
+    assert model.corr_coef is not None
+
+
+def test_predict_score_proba(dummy_data, fitted_model):
+
+    probs = fitted_model.predict_score_proba(
+        dummy_data["home_team"],
+        dummy_data["away_team"],
+        dummy_data["home_goals"],
+        dummy_data["away_goals"],
+    )
+
+    assert jnp.all((probs >= 0.0) <= (probs <= 1.0))
+
+    prob_single = fitted_model.predict_score_proba("A", "B", 1, 0)[0]
+    assert (prob_single >= 0) and (prob_single <= 1)


### PR DESCRIPTION
This PR implements a simple Dixon and Coles model (i.e., the original Dixon & Coles model with minimal modifications to make it a hierarchical model - meaning that there are independent priors for the attack and defence parameters).

I think we can use this as a base for building more complicated versions (including at least the one that is in the current version of `bpl`). There are a few things to add to the model here in order to reproduce the current one in bpl:

* Team-level covariates in the prior.
* Per-team home advantage.
* Correlation between the attack and defence parameters in the prior.

I'd also be keen to hear thoughts on some API changes from the other version of `bpl`:

* I removed the dependency on `pandas` - stuff is just passed around in dicts or lists. It seemed a heavy dependency but it's not really required (the `.dict()` method could be used on dataframes if the upstream data processing uses `pandas`).
* the training data is now passed to `fit` (a la scikit-learn), instead of init.
* the two main functions for prediction are `predict_score_proba` and `predict_outcome_proba` (both vectorised) which produce predictions for specific scorelines and overall outcomes (home win, etc.) respectively.