### PR TITLE
Fix `numpyro` version for M1 mac

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -207,7 +207,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "numpyro"
-version = "0.6.0"
+version = "0.10.0"
 description = "Pyro PPL on NumPy"
 category = "main"
 optional = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Angus Williams <anguswilliams91@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = ">=3.7.1,<4.0"
-numpyro = "^0.6.0"
+numpyro = ">=0.6.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Angus Williams <anguswilliams91@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = ">=3.7.1,<4.0"
-numpyro = ">=0.6.0"
+numpyro = ">=0.6.0, <1.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
Fix for [AIrsenal](https://github.com/alan-turing-institute/AIrsenal) allowing to use `numpyro >= 0.6.0`  