### PR TITLE
update order of dictionary for predicting outcomes

### DIFF
--- a/bpl/dynamic_dixon_coles.py
+++ b/bpl/dynamic_dixon_coles.py
@@ -1,4 +1,4 @@
-"""Implementation of the neutral model in the current version of bpl for predicting the World Cup."""
+"""Implementation of the neutral model with dynamic parameters in the current version of bpl."""
 from __future__ import annotations
 
 import warnings
@@ -16,11 +16,10 @@ from numpyro.infer.reparam import LocScaleReparam
 from bpl._util import compute_corr_coef_bounds, dixon_coles_correlation_term
 from bpl.base import MAX_GOALS
 
-__all__ = ["NeutralDixonColesMatchPredictorWC"]
+__all__ = ["DynamicNeutralDixonColesMatchPredictor"]
 
 
-# pylint: disable=too-many-instance-attributes
-class NeutralDixonColesMatchPredictorWC:
+class DynamicNeutralDixonColesMatchPredictor:
     """
     A Dixon-Coles like model for predicting match outcomes, modified to:
     - Work for matches in neutral venues (e.g. international tournaments)
@@ -43,8 +42,8 @@ class NeutralDixonColesMatchPredictorWC:
         self.defence_coefficients = None
         self.mean_attack = None
         self.mean_defence = None
-        self.std_attack = None
         self.std_defence = None
+        self.std_attack = None
         self.mean_home_attack = None
         self.mean_away_attack = None
         self.mean_home_defence = None
@@ -58,42 +57,46 @@ class NeutralDixonColesMatchPredictorWC:
         self._team_covariates_mean = None
         self._team_covariates_std = None
 
-    # pylint: disable=too-many-arguments,too-many-locals,duplicate-code
+    # pylint: disable=too-many-locals,duplicate-code
     @staticmethod
     def _model(
         home_team: jnp.array,
         away_team: jnp.array,
+        gameweek: jnp.array,
         num_teams: int,
-        home_conf: jnp.array,
-        away_conf: jnp.array,
-        num_conferences: int,
+        num_gameweeks: int,
         home_goals: Iterable[int],
         away_goals: Iterable[int],
         neutral_venue: Iterable[int],
-        time_diff: Iterable[float],
-        epsilon: float,
-        game_weights: Iterable[float],
-        team_covariates: Optional[np.array] = None,
+        team_covariates: Optional[np.array],
     ):
+        with numpyro.plate("gameweek", num_gameweeks):
+            mean_home_attack = numpyro.sample("mean_home_attack", dist.Normal(0.1, 0.2))
+            mean_away_attack = numpyro.sample(
+                "mean_away_attack", dist.Normal(-0.1, 0.2)
+            )
+            mean_home_defence = numpyro.sample(
+                "mean_home_defence", dist.Normal(0.1, 0.2)
+            )
+            mean_away_defence = numpyro.sample(
+                "mean_away_defence", dist.Normal(-0.1, 0.2)
+            )
+            std_home_attack = numpyro.sample(
+                "std_home_attack", dist.HalfNormal(scale=1.0)
+            )
+            std_away_attack = numpyro.sample(
+                "std_away_attack", dist.HalfNormal(scale=1.0)
+            )
+            std_home_defence = numpyro.sample(
+                "std_home_defence", dist.HalfNormal(scale=1.0)
+            )
+            std_away_defence = numpyro.sample(
+                "std_away_defence", dist.HalfNormal(scale=1.0)
+            )
+            std_attack = numpyro.sample("std_attack", dist.HalfNormal(scale=1.0))
+            std_defence = numpyro.sample("std_defence", dist.HalfNormal(scale=1.0))
         mean_attack = 0.0
         mean_defence = numpyro.sample("mean_defence", dist.Normal(loc=0.0, scale=1.0))
-        std_attack = numpyro.sample("std_attack", dist.HalfNormal(scale=0.5))
-        std_defence = numpyro.sample("std_defence", dist.HalfNormal(scale=0.5))
-        mean_home_attack = numpyro.sample("mean_home_attack", dist.Normal(0.1, 0.2))
-        mean_away_attack = numpyro.sample("mean_away_attack", dist.Normal(-0.1, 0.2))
-        mean_home_defence = numpyro.sample("mean_home_defence", dist.Normal(0.1, 0.2))
-        mean_away_defence = numpyro.sample("mean_away_defence", dist.Normal(-0.1, 0.2))
-        std_home_attack = numpyro.sample("std_home_attack", dist.HalfNormal(scale=1.0))
-        std_away_attack = numpyro.sample("std_away_attack", dist.HalfNormal(scale=1.0))
-        std_home_defence = numpyro.sample(
-            "std_home_defence", dist.HalfNormal(scale=1.0)
-        )
-        std_away_defence = numpyro.sample(
-            "std_away_defence", dist.HalfNormal(scale=1.0)
-        )
-
-        u = numpyro.sample("u", dist.Beta(concentration1=2.0, concentration0=4.0))
-        rho = numpyro.deterministic("rho", 2.0 * u - 1.0)
 
         if team_covariates is not None:
             standardised_covariates = (
@@ -120,91 +123,125 @@ class NeutralDixonColesMatchPredictorWC:
             defence_prior_mean = mean_defence
 
         with numpyro.plate("teams", num_teams):
-            standardised_attack = numpyro.sample(
-                "standardised_attack", dist.Normal(loc=0.0, scale=1.0)
-            )
-            standardised_defence = numpyro.sample(
-                "standardised_defence",
-                dist.Normal(
-                    loc=rho * standardised_attack, scale=jnp.sqrt(1.0 - rho**2.0)
-                ),
-            )
-            with reparam(config={"home_attack": LocScaleReparam(centered=0)}):
-                home_attack = numpyro.sample(
-                    "home_attack",
-                    dist.Normal(mean_home_attack, std_home_attack),
+            with numpyro.plate("gameweek", num_gameweeks):
+                u = numpyro.sample(
+                    "u", dist.Beta(concentration1=2.0, concentration0=4.0)
                 )
-            with reparam(config={"away_attack": LocScaleReparam(centered=0)}):
-                away_attack = numpyro.sample(
-                    "away_attack",
-                    dist.Normal(mean_away_attack, std_away_attack),
+                rho = numpyro.deterministic("rho", 2.0 * u - 1.0)
+                standardised_attack = numpyro.sample(
+                    "standardised_attack", dist.Normal(loc=0.0, scale=1.0)
                 )
-            with reparam(config={"home_defence": LocScaleReparam(centered=0)}):
-                home_defence = numpyro.sample(
-                    "home_defence",
-                    dist.Normal(mean_home_defence, std_home_defence),
+                standardised_defence = numpyro.sample(
+                    "standardised_defence",
+                    dist.Normal(
+                        loc=rho * standardised_attack, scale=jnp.sqrt(1.0 - rho**2.0)
+                    ),
                 )
-            with reparam(config={"away_defence": LocScaleReparam(centered=0)}):
-                away_defence = numpyro.sample(
-                    "away_defence",
-                    dist.Normal(mean_away_defence, std_away_defence),
-                )
-        attack = numpyro.deterministic(
-            "attack", attack_prior_mean + standardised_attack * std_attack
-        )
-        defence = numpyro.deterministic(
-            "defence", defence_prior_mean + standardised_defence * std_defence
-        )
 
-        with numpyro.plate("confederations", num_conferences):
-            with reparam(
-                config={"confederation_strength": LocScaleReparam(centered=0)}
-            ):
-                confederation_strength = numpyro.sample(
-                    "confederation_strength", dist.Normal(0.0, 1.0)
+                with reparam(config={"home_attack": LocScaleReparam(centered=0)}):
+                    home_attack = numpyro.sample(
+                        "home_attack",
+                        dist.Normal(
+                            jnp.repeat(mean_home_attack, num_teams).reshape(
+                                num_gameweeks, num_teams
+                            ),
+                            jnp.repeat(std_home_attack, num_teams).reshape(
+                                num_gameweeks, num_teams
+                            ),
+                        ),
+                    )
+                with reparam(config={"away_attack": LocScaleReparam(centered=0)}):
+                    away_attack = numpyro.sample(
+                        "away_attack",
+                        dist.Normal(
+                            jnp.repeat(mean_away_attack, num_teams).reshape(
+                                num_gameweeks, num_teams
+                            ),
+                            jnp.repeat(std_away_attack, num_teams).reshape(
+                                num_gameweeks, num_teams
+                            ),
+                        ),
+                    )
+                with reparam(config={"home_defence": LocScaleReparam(centered=0)}):
+                    home_defence = numpyro.sample(
+                        "home_defence",
+                        dist.Normal(
+                            jnp.repeat(mean_home_defence, num_teams).reshape(
+                                num_gameweeks, num_teams
+                            ),
+                            jnp.repeat(std_home_defence, num_teams).reshape(
+                                num_gameweeks, num_teams
+                            ),
+                        ),
+                    )
+                with reparam(config={"away_defence": LocScaleReparam(centered=0)}):
+                    away_defence = numpyro.sample(
+                        "away_defence",
+                        dist.Normal(
+                            jnp.repeat(mean_away_defence, num_teams).reshape(
+                                num_gameweeks, num_teams
+                            ),
+                            jnp.repeat(std_away_defence, num_teams).reshape(
+                                num_gameweeks, num_teams
+                            ),
+                        ),
+                    )
+        # why aren't these standardised? if they are, how?
+        # what is standardised_attack and standardised_defence actually doing
+        attack = jnp.empty([num_gameweeks, num_teams])
+        defence = jnp.empty([num_gameweeks, num_teams])
+        attack.at[0, ...].set(
+            numpyro.deterministic(
+                "attack_0",
+                attack_prior_mean + standardised_attack[0, ...] * std_attack[0],
+            )
+        )
+        defence.at[0, ...].set(
+            numpyro.deterministic(
+                "defence_0",
+                defence_prior_mean + standardised_defence[0, ...] * std_defence[0],
+            )
+        )
+        for j in range(1, num_gameweeks):
+            attack.at[j, ...].set(
+                numpyro.deterministic(
+                    f"attack_{j}",
+                    attack[j - 1, ...] + standardised_attack[j, ...] * std_attack[j],
                 )
+            )
+            defence.at[j, ...].set(
+                numpyro.deterministic(
+                    f"defence_{j}",
+                    defence[j - 1, ...] + standardised_defence[j, ...] * std_defence[j],
+                )
+            )
 
         expected_home_goals = jnp.exp(
-            attack[home_team]
-            - defence[away_team]
-            + confederation_strength[home_conf]
-            - confederation_strength[away_conf]
-            + (1 - neutral_venue) * home_attack[home_team]
-            - (1 - neutral_venue) * away_defence[away_team]
+            attack[gameweek, home_team]
+            - defence[gameweek, away_team]
+            + (1 - neutral_venue) * home_attack[gameweek, home_team]
+            - (1 - neutral_venue) * away_defence[gameweek, away_team]
         )
         expected_away_goals = jnp.exp(
-            attack[away_team]
-            - defence[home_team]
-            + confederation_strength[away_conf]
-            - confederation_strength[home_conf]
-            + (1 - neutral_venue) * away_attack[away_team]
-            - (1 - neutral_venue) * home_defence[home_team]
+            attack[gameweek, away_team]
+            - defence[gameweek, home_team]
+            + (1 - neutral_venue) * away_attack[gameweek, away_team]
+            - (1 - neutral_venue) * home_defence[gameweek, home_team]
         )
 
-        weights = jnp.exp(-epsilon * time_diff) * game_weights
-        with numpyro.plate("data", len(home_goals)), numpyro.handlers.scale(
-            scale=weights
-        ):
-            numpyro.sample(
-                "home_goals", dist.Poisson(expected_home_goals), obs=home_goals
-            )
-            numpyro.sample(
-                "away_goals", dist.Poisson(expected_away_goals), obs=away_goals
-            )
+        numpyro.sample(
+            "home_goals", dist.Poisson(expected_home_goals).to_event(1), obs=home_goals
+        )
+        numpyro.sample(
+            "away_goals", dist.Poisson(expected_away_goals).to_event(1), obs=away_goals
+        )
 
         # impose bounds on the correlation coefficient
-        corr_coef_raw = numpyro.sample(
-            "corr_coef_raw", dist.Beta(concentration1=2.0, concentration0=2.0)
-        )
+        corr_coef_raw = numpyro.sample("corr_coef_raw", dist.Uniform(low=0.0, high=1.0))
         LB, UB = compute_corr_coef_bounds(expected_home_goals, expected_away_goals)
         corr_coef = numpyro.deterministic("corr_coef", LB + corr_coef_raw * (UB - LB))
         corr_term = dixon_coles_correlation_term(
-            home_goals,
-            away_goals,
-            expected_home_goals,
-            expected_away_goals,
-            corr_coef,
-            weights,
+            home_goals, away_goals, expected_home_goals, expected_away_goals, corr_coef
         )
         numpyro.factor("correlation_term", corr_term.sum(axis=-1))
 
@@ -212,32 +249,20 @@ class NeutralDixonColesMatchPredictorWC:
     def fit(
         self,
         training_data: Dict[str, Union[Iterable[str], Iterable[float]]],
-        epsilon: float = 0.0,
         random_state: int = 42,
         num_warmup: int = 500,
         num_samples: int = 1000,
         mcmc_kwargs: Optional[Dict[str, Any]] = None,
         run_kwargs: Optional[Dict[str, Any]] = None,
-    ) -> NeutralDixonColesMatchPredictorWC:
+    ) -> DynamicNeutralDixonColesMatchPredictor:
 
         home_team = training_data["home_team"]
         away_team = training_data["away_team"]
         team_covariates = training_data.get("team_covariates")
-        home_team_conf = training_data["home_conf"]
-        away_team_conf = training_data["away_conf"]
 
         self.teams = sorted(list(set(home_team) | set(away_team)))
         home_ind = jnp.array([self.teams.index(t) for t in home_team])
         away_ind = jnp.array([self.teams.index(t) for t in away_team])
-
-        self.conferences = sorted(list(set(home_team_conf) | set(away_team_conf)))
-        # lookup for what each number represents
-        self.conferences_ref = dict(zip(range(len(self.conferences)), self.conferences))
-        home_conf_ind = jnp.array([self.conferences.index(t) for t in home_team_conf])
-        away_conf_ind = jnp.array([self.conferences.index(t) for t in away_team_conf])
-
-        self.time_diff = training_data["time_diff"]
-        self.game_weights = training_data["game_weights"]
 
         if team_covariates:
             if set(team_covariates.keys()) != set(self.teams):
@@ -256,28 +281,29 @@ class NeutralDixonColesMatchPredictorWC:
             **(mcmc_kwargs or {}),
         )
         rng_key = jax.random.PRNGKey(random_state)
+        num_gameweeks = max(np.array(training_data["gameweek"], dtype=int))
         mcmc.run(
             rng_key,
             home_ind,
             away_ind,
+            np.array(training_data["gameweek"], dtype=int),
             len(self.teams),
-            home_conf_ind,
-            away_conf_ind,
-            len(self.conferences),
+            num_gameweeks,
             np.array(training_data["home_goals"]),
             np.array(training_data["away_goals"]),
             np.array(training_data["neutral_venue"]),
-            self.time_diff,
-            epsilon,
-            self.game_weights,
             team_covariates=team_covariates,
             **(run_kwargs or {}),
         )
 
         samples = mcmc.get_samples()
-        self.confederation_strength = samples["confederation_strength"]
-        self.attack = samples["attack"]
-        self.defence = samples["defence"]
+        print(samples["attack_0"].shape)
+        print(samples["attack_1"].shape)
+        print(samples[f"attack_{num_gameweeks-1}"].shape)
+        print([samples[f"attack_{j}"].shape for j in range(num_gameweeks)])
+        print([samples[f"defence_{j}"].shape for j in range(num_gameweeks)])
+        self.attack = [samples[f"attack_{j}"] for j in range(num_gameweeks)]
+        self.defence = [samples[f"defence_{j}"] for j in range(num_gameweeks)]
         self.home_attack = samples["home_attack"]
         self.away_attack = samples["away_attack"]
         self.home_defence = samples["home_defence"]
@@ -292,16 +318,15 @@ class NeutralDixonColesMatchPredictorWC:
         self.std_attack = samples["std_attack"]
         self.std_defence = samples["std_defence"]
         self.mean_home_attack = samples["mean_home_attack"]
-        self.mean_away_attack = samples["mean_away_attack"]
+        self.mean_away_attack = samples["mean_home_attack"]
         self.mean_home_defence = samples["mean_home_defence"]
         self.mean_away_defence = samples["mean_away_defence"]
         self.std_home_attack = samples["std_home_attack"]
-        self.std_home_defence = samples["std_home_defence"]
         self.std_away_attack = samples["std_away_attack"]
+        self.std_home_defence = samples["std_home_defence"]
         self.std_away_defence = samples["std_away_defence"]
         self.standardised_attack = samples["standardised_attack"]
         self.standardised_defence = samples["standardised_defence"]
-        self.epsilon = epsilon
 
         return self
 
@@ -309,36 +334,26 @@ class NeutralDixonColesMatchPredictorWC:
         self,
         home_team: Union[str, Iterable[str]],
         away_team: Union[str, Iterable[str]],
-        home_conf: Union[str, Iterable[str]],
-        away_conf: Union[str, Iterable[str]],
         neutral_venue: Union[int, Iterable[int]],
     ) -> Tuple[jnp.array, jnp.array]:
 
         home_ind = jnp.array([self.teams.index(t) for t in home_team])
         away_ind = jnp.array([self.teams.index(t) for t in away_team])
         neutral_venue = jnp.array(neutral_venue)
-        home_conf_ind = jnp.array([self.conferences.index(t) for t in home_conf])
-        away_conf_ind = jnp.array([self.conferences.index(t) for t in away_conf])
 
         attack_home, defence_home = self.attack[:, home_ind], self.defence[:, home_ind]
         attack_away, defence_away = self.attack[:, away_ind], self.defence[:, away_ind]
-        home_conf_strength = self.confederation_strength[:, home_conf_ind]
-        away_conf_strength = self.confederation_strength[:, away_conf_ind]
 
         home_rate = jnp.exp(
             attack_home
             - defence_away
-            + home_conf_strength
-            - away_conf_strength
             + (1 - neutral_venue) * self.home_attack[:, home_ind]
-            - (1 - neutral_venue) * self.away_defence[:, away_ind]
+            + (1 - neutral_venue) * self.away_defence[:, away_ind]
         )
         away_rate = jnp.exp(
             attack_away
             - defence_home
-            + away_conf_strength
-            - home_conf_strength
-            + (1 - neutral_venue) * self.away_attack[:, away_ind]
+            - (1 - neutral_venue) * self.away_attack[:, away_ind]
             - (1 - neutral_venue) * self.home_defence[:, home_ind]
         )
 
@@ -348,8 +363,6 @@ class NeutralDixonColesMatchPredictorWC:
         self,
         home_team: Union[str, Iterable[str]],
         away_team: Union[str, Iterable[str]],
-        home_conf: Union[str, Iterable[str]],
-        away_conf: Union[str, Iterable[str]],
         home_goals: Union[int, Iterable[int]],
         away_goals: Union[int, Iterable[int]],
         neutral_venue: Union[int, Iterable[int]],
@@ -357,11 +370,9 @@ class NeutralDixonColesMatchPredictorWC:
 
         home_team = [home_team] if isinstance(home_team, str) else home_team
         away_team = [away_team] if isinstance(away_team, str) else away_team
-        home_conf = [home_conf] if isinstance(home_conf, str) else home_conf
-        away_conf = [away_conf] if isinstance(away_conf, str) else away_conf
 
         expected_home_goals, expected_away_goals = self._calculate_expected_goals(
-            home_team, away_team, home_conf, away_conf, neutral_venue
+            home_team, away_team, neutral_venue
         )
         corr_term = dixon_coles_correlation_term(
             home_goals,
@@ -371,10 +382,10 @@ class NeutralDixonColesMatchPredictorWC:
             self.corr_coef,
         )
 
-        home_probs = dist.Poisson(expected_home_goals).log_prob(home_goals)
-        away_probs = dist.Poisson(expected_away_goals).log_prob(away_goals)
+        home_probs = jnp.exp(dist.Poisson(expected_home_goals).log_prob(home_goals))
+        away_probs = jnp.exp(dist.Poisson(expected_away_goals).log_prob(away_goals))
 
-        sampled_probs = jnp.exp(corr_term + home_probs + away_probs)
+        sampled_probs = jnp.exp(corr_term) * home_probs * away_probs
         return sampled_probs.mean(axis=0)
 
     def add_new_team(self, team_name: str, team_covariates: Optional[np.array] = None):
@@ -407,18 +418,10 @@ class NeutralDixonColesMatchPredictorWC:
         log_b_tilde = np.random.normal(
             loc=self.rho * log_a_tilde, scale=np.sqrt(1 - self.rho**2.0)
         )
-        home_attack = np.random.normal(
-            loc=self.mean_home_attack, scale=self.std_home_attack
-        )
-        away_attack = np.random.normal(
-            loc=self.mean_away_attack, scale=self.std_away_attack
-        )
-        home_defence = np.random.normal(
-            loc=self.mean_home_defence, scale=self.std_home_defence
-        )
-        away_defence = np.random.normal(
-            loc=self.mean_away_defence, scale=self.std_away_defence
-        )
+        home_attack = np.random.normal(loc=self.mean_home, scale=self.std_home)
+        away_attack = np.random.normal(loc=self.mean_home, scale=self.std_home)
+        home_defence = np.random.normal(loc=self.mean_home, scale=self.std_home)
+        away_defence = np.random.normal(loc=self.mean_home, scale=self.std_home)
         attack = mean_attack + log_a_tilde * self.std_attack
         defence = mean_defence + log_b_tilde * self.std_defence
 
@@ -442,8 +445,6 @@ class NeutralDixonColesMatchPredictorWC:
         self,
         home_team: Union[str, Iterable[str]],
         away_team: Union[str, Iterable[str]],
-        home_conf: Union[str, Iterable[str]],
-        away_conf: Union[str, Iterable[str]],
         neutral_venue: Union[int, Iterable[int]],
     ) -> Dict[str, jnp.array]:
         """Calculate home win, away win and draw probabilities.
@@ -463,8 +464,6 @@ class NeutralDixonColesMatchPredictorWC:
         """
         home_team = [home_team] if isinstance(home_team, str) else home_team
         away_team = [away_team] if isinstance(away_team, str) else away_team
-        home_conf = [home_conf] if isinstance(home_conf, str) else home_conf
-        away_conf = [away_conf] if isinstance(away_conf, str) else away_conf
 
         # make a grid of scorelines up to plausible limits
         n_goals = np.arange(0, MAX_GOALS + 1)
@@ -473,19 +472,11 @@ class NeutralDixonColesMatchPredictorWC:
         y_flat = jnp.tile(y.reshape((MAX_GOALS + 1) ** 2), len(home_team))
         home_team_rep = np.repeat(home_team, (MAX_GOALS + 1) ** 2)
         away_team_rep = np.repeat(away_team, (MAX_GOALS + 1) ** 2)
-        home_conf_rep = np.repeat(home_conf, (MAX_GOALS + 1) ** 2)
-        away_conf_rep = np.repeat(away_conf, (MAX_GOALS + 1) ** 2)
         neutral_venue_rep = np.repeat(neutral_venue, (MAX_GOALS + 1) ** 2)
 
         # evaluate the probability of scorelines at each gridpoint
         probs = self.predict_score_proba(
-            home_team_rep,
-            away_team_rep,
-            home_conf_rep,
-            away_conf_rep,
-            x_flat,
-            y_flat,
-            neutral_venue_rep,
+            home_team_rep, away_team_rep, x_flat, y_flat, neutral_venue_rep
         ).reshape(len(home_team), MAX_GOALS + 1, MAX_GOALS + 1)
 
         # obtain outcome probabilities by summing the appropriate elements of the grid
@@ -493,15 +484,13 @@ class NeutralDixonColesMatchPredictorWC:
         prob_away_win = probs[:, x < y].sum(axis=-1)
         prob_draw = probs[:, x == y].sum(axis=-1)
 
-        return {"home_win": prob_home_win, "draw": prob_draw, "away_win": prob_away_win}
+        return {"home_win": prob_home_win, "away_win": prob_away_win, "draw": prob_draw}
 
     def predict_score_n_proba(
         self,
         n: Union[int, Iterable[int]],
         team: Union[str, Iterable[str]],
         opponent: Union[str, Iterable[str]],
-        team_conf: Union[str, Iterable[str]],
-        opponent_conf: Union[str, Iterable[str]],
         home: Optional[bool] = True,
         neutral_venue: Optional[int] = 0,
     ) -> jnp.array:
@@ -526,31 +515,17 @@ class NeutralDixonColesMatchPredictorWC:
         # flat lists of all possible scorelines with team scoring n goals
         team_rep = np.repeat(team, (MAX_GOALS + 1) * len(n))
         opponent_rep = np.repeat(opponent, (MAX_GOALS + 1) * len(n))
-        team_conf_rep = np.repeat(team_conf, (MAX_GOALS + 1) * len(n))
-        opponent_conf_rep = np.repeat(opponent_conf, (MAX_GOALS + 1) * len(n))
         n_rep = np.resize(n, (MAX_GOALS + 1) * len(n))
         x_rep = np.repeat(np.arange(MAX_GOALS + 1), len(n))
         neutral_venue_rep = np.repeat(neutral_venue, (MAX_GOALS + 1) * len(n))
 
         probs = (
             self.predict_score_proba(
-                team_rep,
-                opponent_rep,
-                team_conf_rep,
-                opponent_conf_rep,
-                n_rep,
-                x_rep,
-                neutral_venue_rep,
+                team_rep, opponent_rep, n_rep, x_rep, neutral_venue_rep
             )
             if home
             else self.predict_score_proba(
-                opponent_rep,
-                team_rep,
-                opponent_conf_rep,
-                team_conf_rep,
-                x_rep,
-                n_rep,
-                neutral_venue_rep,
+                opponent_rep, team_rep, x_rep, n_rep, neutral_venue_rep
             )
         ).reshape(MAX_GOALS + 1, len(n))
 
@@ -562,8 +537,6 @@ class NeutralDixonColesMatchPredictorWC:
         n: Union[int, Iterable[int]],
         team: Union[str, Iterable[str]],
         opponent: Union[str, Iterable[str]],
-        team_conf: Union[str, Iterable[str]],
-        opponent_conf: Union[str, Iterable[str]],
         home: Optional[bool] = True,
         neutral_venue: Optional[int] = 0,
     ) -> jnp.array:
@@ -588,31 +561,17 @@ class NeutralDixonColesMatchPredictorWC:
         # flat lists of all possible scorelines with team conceding n goals
         team_rep = np.repeat(team, (MAX_GOALS + 1) * len(n))
         opponent_rep = np.repeat(opponent, (MAX_GOALS + 1) * len(n))
-        team_conf_rep = np.repeat(team_conf, (MAX_GOALS + 1) * len(n))
-        opponent_conf_rep = np.repeat(opponent_conf, (MAX_GOALS + 1) * len(n))
         n_rep = np.resize(n, (MAX_GOALS + 1) * len(n))
         x_rep = np.repeat(np.arange(MAX_GOALS + 1), len(n))
         neutral_venue_rep = np.repeat(neutral_venue, (MAX_GOALS + 1) * len(n))
 
         probs = (
             self.predict_score_proba(
-                team_rep,
-                opponent_rep,
-                team_conf_rep,
-                opponent_conf_rep,
-                x_rep,
-                n_rep,
-                neutral_venue_rep,
+                team_rep, opponent_rep, x_rep, n_rep, neutral_venue_rep
             )
             if home
             else self.predict_score_proba(
-                opponent_rep,
-                team_rep,
-                opponent_conf_rep,
-                team_conf_rep,
-                n_rep,
-                x_rep,
-                neutral_venue_rep,
+                opponent_rep, team_rep, n_rep, x_rep, neutral_venue_rep
             )
         ).reshape(MAX_GOALS + 1, len(n))
 


### PR DESCRIPTION
necessary change in the order of the predictions in the dictionary that is returned when predicting the outcome of matches, so that brier score and rps score has the right ordering (need it to be home-win, draw, away-win order)