### PR TITLE
Feature/neutral dixon coles

### DIFF
--- a/bpl/_util.py
+++ b/bpl/_util.py
@@ -6,6 +6,10 @@ import jax.numpy as jnp
 import numpy as np
 
 
+def str_to_list(*args):
+    return ([x] if isinstance(x, str) else x for x in args)
+
+
 def compute_corr_coef_bounds(
     expected_home_goals: jnp.array, expected_away_goals: jnp.array
 ) -> Tuple[float, float]:

--- a/bpl/_util.py
+++ b/bpl/_util.py
@@ -27,6 +27,7 @@ def compute_corr_coef_bounds(
     return LB, UB
 
 
+# pylint: disable=too-many-arguments
 def dixon_coles_correlation_term(
     home_goals: Union[int, Iterable[int]],
     away_goals: Union[int, Iterable[int]],

--- a/bpl/neutral_dixon_coles_WC.py
+++ b/bpl/neutral_dixon_coles_WC.py
@@ -15,14 +15,10 @@ from numpyro.handlers import reparam
 from numpyro.infer import MCMC, NUTS
 from numpyro.infer.reparam import LocScaleReparam
 
-from bpl._util import compute_corr_coef_bounds, dixon_coles_correlation_term, map_choice
+from bpl._util import str_to_list, compute_corr_coef_bounds, dixon_coles_correlation_term, map_choice
 from bpl.base import DTYPES, MAX_GOALS
 
 __all__ = ["NeutralDixonColesMatchPredictorWC"]
-
-
-def _str_to_list(*args):
-    return ([x] if isinstance(x, str) else x for x in args)
 
 
 # pylint: disable=too-many-instance-attributes
@@ -31,6 +27,9 @@ class NeutralDixonColesMatchPredictorWC:
     A Dixon-Coles like model for predicting match outcomes, modified to:
     - Work for matches in neutral venues (e.g. international tournaments)
     - Add separate home & away, defence & attack, advantages/disadvantages for each team
+    - Add parameters to describe the strength (or weakness) of particular confederations
+    - Add possibility to downweight games exponentially according to time
+    - Add possibility to weight games according to match importance
     """
 
     # pylint: disable=duplicate-code
@@ -229,7 +228,6 @@ class NeutralDixonColesMatchPredictorWC:
         mcmc_kwargs: Optional[Dict[str, Any]] = None,
         run_kwargs: Optional[Dict[str, Any]] = None,
     ) -> NeutralDixonColesMatchPredictorWC:
-
         home_team = training_data["home_team"]
         away_team = training_data["away_team"]
         team_covariates = training_data.get("team_covariates")
@@ -321,6 +319,31 @@ class NeutralDixonColesMatchPredictorWC:
 
         return self
 
+    def _parse_fixture_args(
+        self, home_team, away_team, home_conf, away_conf, neutral_venue
+    ):
+        home_team, away_team, home_conf, away_conf = str_to_list(
+            home_team, away_team, home_conf, away_conf
+        )
+        neutral_venue = jnp.array(neutral_venue, DTYPES["venue"])
+        if isinstance(home_team[0], str):
+            home_team = jnp.array(
+                [self._teams_dict[t] for t in home_team], DTYPES["teams"]
+            )
+        if isinstance(away_team[0], str):
+            away_team = jnp.array(
+                [self._teams_dict[t] for t in away_team], DTYPES["teams"]
+            )
+        if isinstance(home_conf[0], str):
+            home_conf = jnp.array(
+                [self._conferences_dict[hc] for hc in home_conf], DTYPES["conferences"]
+            )
+        if isinstance(away_conf[0], str):
+            away_conf = jnp.array(
+                [self._conferences_dict[ac] for ac in away_conf], DTYPES["conferences"]
+            )
+        return home_team, away_team, home_conf, away_conf, neutral_venue
+
     def _calculate_expected_goals(
         self,
         home_team: Union[str, Iterable[str]],
@@ -329,6 +352,20 @@ class NeutralDixonColesMatchPredictorWC:
         away_conf: Union[str, Iterable[str]],
         neutral_venue: Union[int, Iterable[int]],
     ) -> Tuple[jnp.array, jnp.array]:
+        """Computes the rate (mean) for the Poisson distribution to model
+        the goals scored by home_team and away_team.
+
+        Args:
+            home_team (Union[str, Iterable[str]]): name of the home team(s).
+            away_team (Union[str, Iterable[str]]): name of the away team(s).
+            home_conf (Union[str, Iterable[str]]): conference of the home team(s).
+            away_conf (Union[str, Iterable[str]]): conference of the away team(s).
+            neutral_venue (Union[int, Iterable[int]]): 1 if game played at neutral venue,
+                else 0.
+
+        Returns:
+            Tuple[jnp.array, jnp.array]: Tuple of arrays for home and away rates.
+        """
         (
             home_team,
             away_team,
@@ -378,6 +415,21 @@ class NeutralDixonColesMatchPredictorWC:
         away_goals: Union[int, Iterable[int]],
         neutral_venue: Union[int, Iterable[int]],
     ) -> jnp.array:
+        """Compute probability of a particular scoreline between two teams.
+
+        Args:
+            home_team (Union[str, Iterable[str]]): name of the home team(s).
+            away_team (Union[str, Iterable[str]]): name of the away team(s).
+            home_conf (Union[str, Iterable[str]]): conference of the home team(s).
+            away_conf (Union[str, Iterable[str]]): conference of the away team(s).
+            home_goals (Union[int, Iterable[int]]): number of goals scored by the home team(s).
+            away_goals (Union[int, Iterable[int]]): number of goals scored by the away team(s).
+            neutral_venue (Union[int, Iterable[int]]): 1 if game played at neutral venue,
+                else 0.
+
+        Returns:
+            jnp.array: Array of probabilities of each scoreline.
+        """
         (
             home_team,
             away_team,
@@ -406,6 +458,16 @@ class NeutralDixonColesMatchPredictorWC:
         return sampled_probs.mean(axis=0)
 
     def add_new_team(self, team_name: str, team_covariates: Optional[np.array] = None):
+        """Method for adding another team to the model.
+
+        Args:
+            team_name (str): team name
+            team_covariates (Optional[np.array], optional): team covariates to
+                initialise prior distribution. Defaults to None.
+
+        Raises:
+            ValueError: if `team_name` is already known to the model.
+        """
         if team_name in self.teams:
             raise ValueError(f"Team {team_name} already known to model.")
 
@@ -466,35 +528,28 @@ class NeutralDixonColesMatchPredictorWC:
             (self.away_defence, away_defence[:, None]), axis=1
         )
 
-    def _parse_fixture_args(
-        self, home_team, away_team, home_conf, away_conf, neutral_venue
-    ):
-        home_team, away_team, home_conf, away_conf = _str_to_list(
-            home_team, away_team, home_conf, away_conf
-        )
-        neutral_venue = jnp.array(neutral_venue, DTYPES["venue"])
-        if isinstance(home_team[0], str):
-            home_team = jnp.array(
-                [self._teams_dict[t] for t in home_team], DTYPES["teams"]
-            )
-        if isinstance(away_team[0], str):
-            away_team = jnp.array(
-                [self._teams_dict[t] for t in away_team], DTYPES["teams"]
-            )
-        if isinstance(home_conf[0], str):
-            home_conf = jnp.array(
-                [self._conferences_dict[hc] for hc in home_conf], DTYPES["conferences"]
-            )
-        if isinstance(away_conf[0], str):
-            away_conf = jnp.array(
-                [self._conferences_dict[ac] for ac in away_conf], DTYPES["conferences"]
-            )
-        return home_team, away_team, home_conf, away_conf, neutral_venue
-
     def predict_score_grid_proba(
-        self, home_team, away_team, home_conf, away_conf, neutral_venue
-    ):
-        """Compute probabilities of all plausible scorelines"""
+        self, 
+        home_team: Union[str, Iterable[str]],
+        away_team: Union[str, Iterable[str]],
+        home_conf: Union[str, Iterable[str]],
+        away_conf: Union[str, Iterable[str]],
+        neutral_venue: Union[int, Iterable[int]],
+    ) -> Tuple[jnp.array, np.array, np.array]:
+        """Calculate scoreline probabilities between two teams.
+
+        Args:
+            home_team (Union[str, Iterable[str]]): name of the home team(s).
+            away_team (Union[str, Iterable[str]]): name of the away team(s).
+            home_conf (Union[str, Iterable[str]]): conference of the home team(s).
+            away_conf (Union[str, Iterable[str]]): conference of the away team(s).
+            neutral_venue (Union[int, Iterable[int]]): 1 if game played at neutral venue,
+                else 0.
+
+        Returns:
+            Tuple[jnp.array, np.array, np.array]: Tuple of the following grids (as arrays):
+                probability of scorelines, home goals and away goals scored grids
+        """
         (
             home_team,
             away_team,
@@ -547,13 +602,15 @@ class NeutralDixonColesMatchPredictorWC:
         Args:
             home_team (Union[str, Iterable[str]]): name of the home team(s).
             away_team (Union[str, Iterable[str]]): name of the away team(s).
+            home_conf (Union[str, Iterable[str]]): conference of the home team(s).
+            away_conf (Union[str, Iterable[str]]): conference of the away team(s).
             neutral_venue (Union[int, Iterable[int]]): 1 if game played at neutral venue,
-            else 0
-            knockout : If True only consider the probability of wins (exclude draws)
+                else 0.
+            knockout : If True only consider the probability of wins (exclude draws).
 
         Returns:
             Dict[str, Union[float, np.ndarray]]: A dictionary with keys "home_win",
-                "away_win" and "draw". Values are probabilities of each outcome.
+                "draw" and "away_win". Values are probabilities of each outcome.
         """
         (
             home_team,
@@ -593,7 +650,23 @@ class NeutralDixonColesMatchPredictorWC:
         neutral_venue: Union[int, Iterable[int]],
         num_samples: int = 1,
         random_state: int = None,
-    ):
+    ) -> Dict[str, jnp.array]:
+        """Sample scoreline between two teams.
+
+        Args:
+            home_team (Union[str, Iterable[str]]): name of the home team(s).
+            away_team (Union[str, Iterable[str]]): name of the away team(s).
+            home_conf (Union[str, Iterable[str]]): conference of the home team(s).
+            away_conf (Union[str, Iterable[str]]): conference of the away team(s).
+            neutral_venue (Union[int, Iterable[int]]): 1 if game played at neutral venue,
+                else 0.
+            num_samples (int, optional): number of simulations. Defaults to 1.
+            random_state (int, optional): seed. Defaults to None.
+
+        Returns:
+            Dict[str, Union[float, np.ndarray]]: A dictionary with keys "home_score" and
+                "away_score". Values are the simulated goals scored in each simulation.
+        """
         (
             home_team,
             away_team,
@@ -635,7 +708,24 @@ class NeutralDixonColesMatchPredictorWC:
         knockout: bool = False,
         num_samples: int = 1,
         random_state: int = None,
-    ):
+    ) -> np.array:
+        """Sample outcome of match between two teams.
+
+        Args:
+            home_team (Union[str, Iterable[str]]): name of the home team(s).
+            away_team (Union[str, Iterable[str]]): name of the away team(s).
+            home_conf (Union[str, Iterable[str]]): conference of the home team(s).
+            away_conf (Union[str, Iterable[str]]): conference of the away team(s).
+            neutral_venue (Union[int, Iterable[int]]): 1 if game played at neutral venue,
+                else 0.
+            knockout : If True only consider the probability of wins (exclude draws).
+            num_samples (int, optional): number of simulations. Defaults to 1.
+            random_state (int, optional): seed. Defaults to None.
+
+        Returns:
+            np.array: Array of strings representing the winning team or 'Draw'
+                ('Draw' only considered if knockout is False).
+        """
         (
             home_team,
             away_team,
@@ -701,9 +791,11 @@ class NeutralDixonColesMatchPredictorWC:
             n (Union[int, Iterable[int]]): number of goals scored.
             team (Union[str, Iterable[str]]): name of the team scoring the goals.
             opponent (Union[str, Iterable[str]]): name of the opponent.
+            team_conf (Union[str, Iterable[str]]): conference of team scoring the goals.
+            opponent_conf (Union[str, Iterable[str]]): conference of the opponent.
             home (Optional[bool]): whether team is at home.
             neutral_venue (Union[int, Iterable[int]]): 1 if game played at neutral venue,
-            else 0
+                else 0.
 
         Returns:
             jnp.array: Probability that team scores n goals against opponent.
@@ -765,9 +857,11 @@ class NeutralDixonColesMatchPredictorWC:
             n (Union[int, Iterable[int]]): number of goals conceded.
             team (Union[str, Iterable[str]]): name of the team conceding the goals.
             opponent (Union[str, Iterable[str]]): name of the opponent.
+            team_conf (Union[str, Iterable[str]]): conference of team conceding the goals.
+            opponent_conf (Union[str, Iterable[str]]): conference of the opponent.
             home (Optional[bool]): whether team is at home.
             neutral_venue (Union[int, Iterable[int]]): 1 if game played at neutral venue,
-            else 0
+                else 0.
 
         Returns:
             jnp.array: Probability that team concedes n goals against opponent.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ import pytest
 
 @pytest.fixture
 def dummy_data():
-
     np.random.seed(42)
     home_mean = 2.1
     away_mean = 1.7
@@ -42,6 +41,8 @@ def neutral_dummy_data():
     away_means = [away_mean if venue == 0 else neutral_mean for venue in neutral_venue]
     home_goals = np.random.poisson(home_means)
     away_goals = np.random.poisson(away_means)
+    time_diff = np.linspace(0, 10, num=190)
+    game_weights = np.random.uniform(0, 10, size=190)
 
     teams = [str(i) for i in range(20)]
     matchups = itertools.combinations(teams, 2)
@@ -51,10 +52,18 @@ def neutral_dummy_data():
         home_team.append(a)
         away_team.append(b)
 
+    conferences = [str(i) for i in range(5)]
+    home_conf = np.random.choice(conferences, 190)
+    away_conf = np.random.choice(conferences, 190)
+
     return {
         "home_team": home_team,
         "away_team": away_team,
+        "home_conf": home_conf,
+        "away_conf": away_conf,
         "home_goals": home_goals,
         "away_goals": away_goals,
         "neutral_venue": neutral_venue,
+        "time_diff": time_diff,
+        "game_weights": game_weights,
     }

--- a/tests/test_neutral_dixon_coles_WC.py
+++ b/tests/test_neutral_dixon_coles_WC.py
@@ -2,16 +2,17 @@ import jax.numpy as jnp
 import pytest
 
 from bpl.base import MAX_GOALS
-from bpl.neutral_dixon_coles import NeutralDixonColesMatchPredictor
+from bpl.neutral_dixon_coles_WC import NeutralDixonColesMatchPredictorWC
 
 TOL = 1e-02
 
 @pytest.fixture
 def model(neutral_dummy_data):
-    return NeutralDixonColesMatchPredictor().fit(neutral_dummy_data)
+    return NeutralDixonColesMatchPredictorWC().fit(neutral_dummy_data)
 
 
 def test_fit(model):
+    assert model.confederation_strength is not None
     assert model.attack is not None
     assert model.defence is not None
     assert model.home_attack is not None
@@ -19,6 +20,7 @@ def test_fit(model):
     assert model.away_attack is not None
     assert model.away_defence is not None
     assert model.teams is not None
+    assert model.conferences is not None
     assert model.corr_coef is not None
 
 
@@ -26,6 +28,8 @@ def test_predict_score_proba(model, neutral_dummy_data):
     probs = model.predict_score_proba(
         neutral_dummy_data["home_team"],
         neutral_dummy_data["away_team"],
+        neutral_dummy_data["home_conf"],
+        neutral_dummy_data["away_conf"],
         neutral_dummy_data["home_goals"],
         neutral_dummy_data["away_goals"],
         neutral_dummy_data["neutral_venue"],
@@ -33,7 +37,7 @@ def test_predict_score_proba(model, neutral_dummy_data):
 
     assert jnp.all((probs >= 0) & (probs <= 1))
 
-    prob_single = model.predict_score_proba("0", "1", 1, 0, 0)[0]
+    prob_single = model.predict_score_proba("0", "1", "0", "1", 1, 0, 0)[0]
     assert 0 <= prob_single <= 1
 
 
@@ -41,6 +45,8 @@ def test_predict_outcome_proba(model, neutral_dummy_data):
     probs = model.predict_outcome_proba(
         neutral_dummy_data["home_team"],
         neutral_dummy_data["away_team"],
+        neutral_dummy_data["home_conf"],
+        neutral_dummy_data["away_conf"],
         neutral_dummy_data["neutral_venue"],
     )
 
@@ -48,7 +54,7 @@ def test_predict_outcome_proba(model, neutral_dummy_data):
 
     assert jnp.allclose(total_probability, 1.0, atol=TOL)
 
-    prob_single = model.predict_outcome_proba("0", "1", 0)
+    prob_single = model.predict_outcome_proba("0", "1", "0", "1", 0)
     assert prob_single["home_win"] + prob_single["away_win"] + prob_single[
         "draw"
     ] == pytest.approx(1.0, abs=TOL)
@@ -56,42 +62,42 @@ def test_predict_outcome_proba(model, neutral_dummy_data):
 
 def test_predict_score_n_proba(model):
     n = jnp.arange(MAX_GOALS + 1)
-    proba_home = model.predict_score_n_proba(n, "0", "1")
+    proba_home = model.predict_score_n_proba(n, "0", "1", "0", "1")
     assert len(proba_home) == len(n)
     assert jnp.all((proba_home >= 0) & (proba_home <= 1))
     assert sum(proba_home) == pytest.approx(1.0, abs=TOL)
 
-    proba_away = model.predict_score_n_proba(n, "0", "1", home=False)
+    proba_away = model.predict_score_n_proba(n, "0", "1", "0", "1", home=False)
     assert len(proba_home) == len(n)
     assert jnp.all((proba_away >= 0) & (proba_away <= 1))
     assert sum(proba_away) == pytest.approx(1.0, abs=TOL)
 
     assert sum(proba_home * n) > sum(proba_away * n)  # score more at home
 
-    proba_single = model.predict_score_n_proba(1, "0", "1")
+    proba_single = model.predict_score_n_proba(1, "0", "1", "0", "1")
     assert len(proba_single) == 1
     assert (proba_single[0] >= 0) and (proba_single[0] <= 1)
 
 
 def test_predict_concede_n_proba(model):
     n = jnp.arange(MAX_GOALS + 1)
-    proba_home = model.predict_concede_n_proba(n, "0", "1")
+    proba_home = model.predict_concede_n_proba(n, "0", "1", "0", "1")
     assert len(proba_home) == len(n)
     assert jnp.all((proba_home >= 0) & (proba_home <= 1))
     assert sum(proba_home) == pytest.approx(1.0, abs=TOL)
 
-    proba_away = model.predict_concede_n_proba(n, "0", "1", home=False)
+    proba_away = model.predict_concede_n_proba(n, "0", "1", "0", "1", home=False)
     assert len(proba_home) == len(n)
     assert jnp.all((proba_away >= 0) & (proba_away <= 1))
     assert sum(proba_away) == pytest.approx(1.0, abs=TOL)
 
     assert sum(proba_home * n) < sum(proba_away * n)  # concede more away
 
-    proba_team_concede = model.predict_concede_n_proba(1, "0", "1")
+    proba_team_concede = model.predict_concede_n_proba(1, "0", "1", "0", "1")
     assert len(proba_team_concede) == 1
     assert (proba_team_concede[0] >= 0) and (proba_team_concede[0] <= 1)
 
-    proba_opponent_score = model.predict_score_n_proba(1, "1", "0", home=False)
+    proba_opponent_score = model.predict_score_n_proba(1, "1", "0", "0", "1", home=False)
     assert proba_team_concede.tolist() == pytest.approx(
         proba_opponent_score.tolist(), abs=TOL
     )
@@ -101,6 +107,8 @@ def test_predict_outcome_neutral_proba(model, neutral_dummy_data):
     probs = model.predict_outcome_proba(
         neutral_dummy_data["home_team"],
         neutral_dummy_data["away_team"],
+        neutral_dummy_data["home_conf"],
+        neutral_dummy_data["away_conf"],
         neutral_dummy_data["neutral_venue"],
     )
 


### PR DESCRIPTION
General update of `NeutralDixonColesMatchPredictor` so that `AIrsenal` can use these new features. Confederation strength is currently not necessary in that setting.

- Added doc strings for `NeutralDixonColesMatchPredictorWC` and `NeutralDixonColesMatchPredictor` models
- Updated `NeutralDixonColesMatchPredictor` to have time and match importance weighting (key difference between the models is just that the WC model allows for modelling confederation strengths)
- Updated `NeutralDixonColesMatchPredictor` to have `sample_score` and `sample_outcome` methods - although I don't think these will be used in `AIrsenal` just yet, but nice to have in the future if we did want to optimise AIrsenal sampling code
- Added tests for WC model (although still not passing all tests due to some NaNs - couldn't really figure out why)